### PR TITLE
Clearing Intellisense messages

### DIFF
--- a/TaskbarX/TaskbarX/Easings.vb
+++ b/TaskbarX/TaskbarX/Easings.vb
@@ -40,9 +40,8 @@ Public Delegate Function EasingDelegate(ByVal currentTime As Double, ByVal minVa
             Dim num2 As Double = maxHeight / 2.0
             Dim x As Double = 2.0
             Dim num3 As Double = -10.0
-            Dim num4 As Double = currentTime - 1.0
-            currentTime = num4
-            Return num2 * (-Math.Pow(x, num3 * num4) + 2.0) + minHeight
+        Dim num4 As Double = currentTime - 1.0
+        Return num2 * (-Math.Pow(x, num3 * num4) + 2.0) + minHeight
         End Function
 
         Public Shared Function ExpoEaseOutIn(currentTime As Double, minHeight As Double, maxHeight As Double, duration As Double) As Double
@@ -138,10 +137,9 @@ Public Delegate Function EasingDelegate(ByVal currentTime As Double, ByVal minVa
             End If
             Dim num2 As Double = -maxHeight / 2.0
             Dim num3 As Double = 3.1415926535897931
-            Dim num4 As Double = currentTime - 1.0
-            currentTime = num4
-            Return num2 * (Math.Cos(num3 * num4 / 2.0) - 2.0) + minHeight
-        End Function
+        Dim num4 As Double = currentTime - 1.0
+        Return num2 * (Math.Cos(num3 * num4 / 2.0) - 2.0) + minHeight
+    End Function
 
         Public Shared Function SineEaseOutIn(currentTime As Double, minHeight As Double, maxHeight As Double, duration As Double) As Double
             If currentTime < duration / 2.0 Then

--- a/TaskbarX/TaskbarX/MSAA.vb
+++ b/TaskbarX/TaskbarX/MSAA.vb
@@ -20,7 +20,7 @@ Public Class MSAA
     Public Shared guidAccessible As New Guid("{00020400-0000-0000-C000-000000000046}")
 
     Public Shared Function GetAccessibleChildren(ByVal objAccessible As IAccessible) As IAccessible()
-        Dim childCount As Integer = 0
+        Dim childCount As Integer
         Try
             childCount = objAccessible.accChildCount
         Catch ex As Exception

--- a/TaskbarX/TaskbarX/Main.vb
+++ b/TaskbarX/TaskbarX/Main.vb
@@ -1,4 +1,4 @@
-﻿Option Strict On
+Option Strict On
 
 Imports System.Runtime.InteropServices
 Imports System.Threading
@@ -235,7 +235,7 @@ Public Class Main
                     itemType.InvokeMember("Refresh", BindingFlags.InvokeMethod, Nothing, item, Nothing)
                 End If
             End If
-            i = (i + 1)
+            i += 1
         Loop
     End Sub
 

--- a/TaskbarX/TaskbarX/TaskbarCenter.vb
+++ b/TaskbarX/TaskbarX/TaskbarCenter.vb
@@ -1,4 +1,4 @@
-﻿Option Strict On
+Option Strict On
 
 
 Imports System.Threading
@@ -91,7 +91,7 @@ Public Class TaskbarCenter
         Return Nothing
     End Function
 
-    Public Shared Sub setpos()
+    Public Shared Sub SetPos()
         If setposori = "H" Then
             Do
                 Win32.SetWindowPos(setposhwnd, IntPtr.Zero, setpospos, 0, 0, 0, Win32.SWP_NOSIZE Or Win32.SWP_ASYNCWINDOWPOS Or Win32.SWP_NOACTIVATE Or Win32.SWP_NOZORDER Or Win32.SWP_NOSENDCHANGING)
@@ -168,7 +168,6 @@ Public Class TaskbarCenter
             Dim Handle As IntPtr
             Do
                 Console.WriteLine("Waiting for Shell_TrayWnd")
-                Handle = Nothing
                 Thread.Sleep(250)
                 Handle = Win32.FindWindowByClass("Shell_TrayWnd", CType(0, IntPtr))
             Loop Until Not Handle = Nothing
@@ -187,7 +186,6 @@ Public Class TaskbarCenter
         Dim Handle As IntPtr
         Do
             Console.WriteLine("Waiting for Shell_TrayWnd")
-            Handle = Nothing
             Thread.Sleep(250)
             Handle = Win32.FindWindowByClass("Shell_TrayWnd", CType(0, IntPtr))
         Loop Until Not Handle = Nothing
@@ -338,7 +336,7 @@ Public Class TaskbarCenter
                         'Put the results into a string ready to be matched for differences with last loop
                         results = results & Orientation & TaskbarCount & TrayWndSize
 
-                        i = (i + 1)
+                        i += 1
                     Next
 
                     If Not results = oldresults Then
@@ -389,7 +387,7 @@ triggerskip:
                     End If
 
                 End Try
-        Loop
+            Loop
 
         Catch ex As Exception
             MessageBox.Show("@Looper2 | " & ex.Message)
@@ -477,7 +475,7 @@ triggerskip:
                             setpospos = CInt(pos)
                             setposori = TrayOrientation
 
-                            Dim t1 As Thread = New Thread(AddressOf setpos)
+                            Dim t1 As Thread = New Thread(AddressOf SetPos)
                             t1.Start()
 
                             Thread.Sleep(5)
@@ -574,10 +572,10 @@ triggerskip:
                         For Each ccc As Accessibility.IAccessible In children2
                             Try
                                 If CInt(childx.accRole(ccc)) = &H2B Or CInt(childx.accRole(ccc)) = &H39 Then 'push button (0x2B) | menu button (0x39)
-                                    Count = Count + 1
+                                    Count += 1
                                 End If
                             Catch
-                                Count = Count + 1
+                                Count += 1
                             End Try
 
                         Next

--- a/TaskbarX/TaskbarX/TaskbarStyle.vb
+++ b/TaskbarX/TaskbarX/TaskbarStyle.vb
@@ -1,4 +1,4 @@
-﻿Option Strict On
+Option Strict On
 
 Imports System.Runtime.InteropServices
 Imports System.Text
@@ -45,7 +45,7 @@ Public Class TaskbarStyle
         Return True
     End Function
 
-    Public Shared Sub ttt()
+    Public Shared Sub Ttt()
         Do
             windowHandles2.Clear()
 
@@ -63,7 +63,7 @@ Public Class TaskbarStyle
             GetActiveWindows()
 
             If Settings.DefaultTaskbarStyleOnWinMax = 1 Then
-                '  Dim t2 As Thread = New Thread(AddressOf ttt)
+                '  Dim t2 As Thread = New Thread(AddressOf Ttt)
                 '   t2.Start()
             End If
 


### PR DESCRIPTION
Removed duplicate/unnecessary assignments
- Easings.vb line 44, 142
- MSAA.vb line 23

Name Convention Refactoring ie.CapitalizeFirstLetter using CamelCase
- TaskbarCenter.vb setpos -> SetPos line 94
- TaskbarCenter.vb line 171, 190, 477
- TaskbarStyle.vb line 46,64

Use x += y instead of x = x + y
- Main.vb line 236
- TaskbarCenter.vb line 338, 574, 577